### PR TITLE
[메인페이지 / 메세지 보내기 페이지] 기능, UI 분리

### DIFF
--- a/src/components/DropDown.jsx
+++ b/src/components/DropDown.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { styled } from 'styled-components';
 import arrowTop from '../assets/arrow_top.svg';
 import arrowDown from '../assets/arrow_right.svg';
-import { useDropdown } from '../hooks/useDropDown';
+import useDropdown from '../hooks/useDropDown';
 
 function OptionList({ options, onChangeInner, onChangeSelected, onBlur }) {
   const handleClickOption = (event) => {

--- a/src/components/DropDown.jsx
+++ b/src/components/DropDown.jsx
@@ -1,7 +1,8 @@
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import { styled } from 'styled-components';
 import arrowTop from '../assets/arrow_top.svg';
 import arrowDown from '../assets/arrow_right.svg';
+import { useDropdown } from '../hooks/useDropDown';
 
 function OptionList({ options, onChangeInner, onChangeSelected, onBlur }) {
   const handleClickOption = (event) => {
@@ -28,20 +29,12 @@ function OptionList({ options, onChangeInner, onChangeSelected, onBlur }) {
 }
 
 function DropDown({ options, handleChange }) {
-  const [isDropdownView, setDropdownView] = useState(false);
   const [innerSelected, setInnerSelected] = useState(options[0].label);
-
-  const handleOnClickDropDown = () => {
-    setDropdownView(!isDropdownView);
-  };
-
-  const handleOnBlurDropDown = () => {
-    setDropdownView(false);
-  };
+  const { isDropdownView, toggleDropdown } = useDropdown();
 
   return (
     <div>
-      <DropdownLabel type="button" onClick={handleOnClickDropDown}>
+      <DropdownLabel type="button" onClick={toggleDropdown}>
         <div className="label">{innerSelected}</div>
         <img
           className="icon"
@@ -54,7 +47,7 @@ function DropDown({ options, handleChange }) {
           options={options}
           onChangeInner={setInnerSelected}
           onChangeSelected={handleChange}
-          onBlur={setDropdownView}
+          onBlur={toggleDropdown}
         />
       ) : null}
     </div>

--- a/src/components/DropDown.jsx
+++ b/src/components/DropDown.jsx
@@ -1,12 +1,13 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { styled } from 'styled-components';
 import arrowTop from '../assets/arrow_top.svg';
 import arrowDown from '../assets/arrow_right.svg';
 
-function OptionList({ options, onChangeInner, onChangeSelected }) {
+function OptionList({ options, onChangeInner, onChangeSelected, onBlur }) {
   const handleClickOption = (event) => {
     onChangeInner(event.target.innerText);
     onChangeSelected(event.target.innerText);
+    onBlur(false);
   };
 
   return (
@@ -40,11 +41,7 @@ function DropDown({ options, handleChange }) {
 
   return (
     <div>
-      <DropdownLabel
-        type="button"
-        onClick={handleOnClickDropDown}
-        onBlur={handleOnBlurDropDown}
-      >
+      <DropdownLabel type="button" onClick={handleOnClickDropDown}>
         <div className="label">{innerSelected}</div>
         <img
           className="icon"
@@ -57,6 +54,7 @@ function DropDown({ options, handleChange }) {
           options={options}
           onChangeInner={setInnerSelected}
           onChangeSelected={handleChange}
+          onBlur={setDropdownView}
         />
       ) : null}
     </div>

--- a/src/components/NameInput.jsx
+++ b/src/components/NameInput.jsx
@@ -1,22 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from 'styled-components';
+import useNameInput from '../hooks/useNameInput';
 
+// prettier-ignore
 function NameInput({ placeholder, handleChange }) {
-  const [isValid, setIsValid] = useState(true);
-
-  const handleChangeInput = (event) => {
-    handleChange(event.target.value);
-  };
-
-  const handleFocus = () => {
-    setIsValid(true);
-  };
-
-  const handleBlur = (event) => {
-    if (event.target.value === '') {
-      setIsValid(false);
-    }
-  };
+  const { isValid, handleChangeInput, handleFocus, handleBlur } = useNameInput(handleChange);
 
   return (
     <InputWrapper>

--- a/src/components/ProfileSelect.jsx
+++ b/src/components/ProfileSelect.jsx
@@ -1,16 +1,10 @@
-import { useState } from 'react';
 import { styled } from 'styled-components';
 import profileImages from '../assets/profile/index';
-import defaultProfileImage from '../assets/profile/0.png';
+import useProfileSelect from '../hooks/useProfileSelect';
 import device from '../config';
 
 function ProfileSelect({ handleChange }) {
-  const [selected, setSelected] = useState(defaultProfileImage);
-
-  const handleClickProfileImage = (event) => {
-    handleChange(event.target.value);
-    setSelected(event.target.value);
-  };
+  const { selected, handleClickProfileImage } = useProfileSelect(handleChange);
 
   return (
     <ProfileSelectWrapper>

--- a/src/components/TextEditor.jsx
+++ b/src/components/TextEditor.jsx
@@ -1,31 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ReactQuill from 'react-quill';
 import { styled } from 'styled-components';
-
-function removeHTMLTags(html) {
-  return html.replace(/<[^>]+>/g, '');
-}
+import useTextEditor from '../hooks/useTextEditor';
 
 function TextEditor({ handleChange, isNotEmpty }) {
-  const [isValid, setIsValid] = useState(true);
-  const [editorContent, setEditorContent] = useState('');
-
-  const handleChangeText = (text) => {
-    const cleanText = removeHTMLTags(text);
-    isNotEmpty(cleanText !== '');
-    handleChange(text);
-    setEditorContent(text);
-  };
-
-  const handleBlur = () => {
-    if (editorContent === '') {
-      setIsValid(false);
-    }
-  };
-
-  const handleFocus = () => {
-    setIsValid(true);
-  };
+  const { isValid, editorContent, handleChangeText, handleBlur, handleFocus } =
+    useTextEditor({ handleChange, isNotEmpty });
 
   return (
     <QuillWrapper>

--- a/src/components/TextEditor.jsx
+++ b/src/components/TextEditor.jsx
@@ -3,9 +3,15 @@ import ReactQuill from 'react-quill';
 import { styled } from 'styled-components';
 import useTextEditor from '../hooks/useTextEditor';
 
+// prettier-ignore
 function TextEditor({ handleChange, isNotEmpty }) {
-  const { isValid, editorContent, handleChangeText, handleBlur, handleFocus } =
-    useTextEditor({ handleChange, isNotEmpty });
+  const {
+    isValid,
+    editorContent,
+    handleChangeText,
+    handleBlur,
+    handleFocus,
+  } = useTextEditor({ handleChange, isNotEmpty });
 
   return (
     <QuillWrapper>

--- a/src/hooks/useDropDown.jsx
+++ b/src/hooks/useDropDown.jsx
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+export function useDropdown() {
+  const [isDropdownView, setDropdownView] = useState(false);
+
+  const toggleDropdown = () => {
+    setDropdownView(!isDropdownView);
+  };
+
+  return {
+    isDropdownView,
+    toggleDropdown,
+  };
+}

--- a/src/hooks/useDropDown.jsx
+++ b/src/hooks/useDropDown.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export function useDropdown() {
+function useDropdown() {
   const [isDropdownView, setDropdownView] = useState(false);
 
   const toggleDropdown = () => {
@@ -12,3 +12,5 @@ export function useDropdown() {
     toggleDropdown,
   };
 }
+
+export default useDropdown;

--- a/src/hooks/useNameInput.jsx
+++ b/src/hooks/useNameInput.jsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+function useNameInput(handleChange) {
+  const [isValid, setIsValid] = useState(true);
+
+  const handleChangeInput = (event) => {
+    handleChange(event.target.value);
+  };
+
+  const handleFocus = () => {
+    setIsValid(true);
+  };
+
+  const handleBlur = (event) => {
+    if (event.target.value === '') {
+      setIsValid(false);
+    }
+  };
+
+  return {
+    isValid,
+    handleChangeInput,
+    handleFocus,
+    handleBlur,
+  };
+}
+
+export default useNameInput;

--- a/src/hooks/useProfileSelect.jsx
+++ b/src/hooks/useProfileSelect.jsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import defaultProfileImage from '../assets/profile/0.png';
+
+function useProfileSelect(handleChange) {
+  const [selected, setSelected] = useState(defaultProfileImage);
+
+  const handleClickProfileImage = (event) => {
+    handleChange(event.target.value);
+    setSelected(event.target.value);
+  };
+
+  return {
+    selected,
+    handleClickProfileImage,
+  };
+}
+
+export default useProfileSelect;

--- a/src/hooks/useSendMessage.jsx
+++ b/src/hooks/useSendMessage.jsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import postMessage from '../api/postMessage';
+
+function useSendMessage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [senderName, setSenderName] = useState('');
+  const [profileImage, setProfileImage] = useState(
+    'https://i.ibb.co/zQGbzDz/image.png',
+  );
+  const [relation, setRelation] = useState('지인');
+  const [message, setMessage] = useState('');
+  const [messageValid, setMessageValid] = useState(false);
+  const [font, setFont] = useState('Noto Sans');
+  const [isFormValid, setIsFormVaild] = useState(false);
+
+  const sendingData = {
+    recipientId: id,
+    sender: senderName,
+    profileImageURL: profileImage,
+    relationship: relation,
+    content: message,
+    font,
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    postMessage(sendingData);
+    navigate(`/post/${id}`);
+  };
+
+  useEffect(() => {
+    const handleFormValid = () => {
+      if (senderName !== '' && messageValid !== false) {
+        setIsFormVaild(true);
+      } else {
+        setIsFormVaild(false);
+      }
+    };
+    handleFormValid();
+  }, [senderName, messageValid]);
+
+  return {
+    setSenderName,
+    setProfileImage,
+    setRelation,
+    setMessage,
+    setMessageValid,
+    setFont,
+    isFormValid,
+    handleSubmit,
+  };
+}
+
+export default useSendMessage;

--- a/src/hooks/useTextEditor.jsx
+++ b/src/hooks/useTextEditor.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+function removeHTMLTags(html) {
+  return html.replace(/<[^>]+>/g, '');
+}
+
+function useTextEditor({ handleChange, isNotEmpty }) {
+  const [isValid, setIsValid] = useState(true);
+  const [editorContent, setEditorContent] = useState('');
+
+  const handleChangeText = (text) => {
+    const cleanText = removeHTMLTags(text);
+    isNotEmpty(cleanText !== '');
+    handleChange(text);
+    setEditorContent(text);
+  };
+
+  const handleBlur = () => {
+    if (editorContent === '') {
+      setIsValid(false);
+    }
+  };
+
+  const handleFocus = () => {
+    setIsValid(true);
+  };
+
+  return {
+    isValid,
+    editorContent,
+    handleChangeText,
+    handleBlur,
+    handleFocus,
+  };
+}
+
+export default useTextEditor;

--- a/src/pages/SendMessagePage.jsx
+++ b/src/pages/SendMessagePage.jsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import React from 'react';
 import { styled } from 'styled-components';
 import GlobalNav from '../components/GlobalNav';
 import ProfileSelect from '../components/ProfileSelect';
@@ -10,47 +9,19 @@ import TextEditor from '../components/TextEditor';
 import Button from '../components/Button';
 import device from '../config';
 import NameInput from '../components/NameInput';
-import postMessage from '../api/postMessage';
+import useSendMessage from '../hooks/useSendMessage';
 
 function SendMessagePage() {
-  const { id } = useParams();
-  const navigate = useNavigate();
-
-  const [senderName, setSenderName] = useState('');
-  const [profileImage, setProfileImage] = useState(
-    'https://i.ibb.co/zQGbzDz/image.png',
-  );
-  const [relation, setRelation] = useState('지인');
-  const [message, setMessage] = useState('');
-  const [messageValid, setMessageValid] = useState(false);
-  const [font, setFont] = useState('Noto Sans');
-  const [isFormValid, setIsFormVaild] = useState(false);
-
-  const sendingData = {
-    recipientId: id,
-    sender: senderName,
-    profileImageURL: profileImage,
-    relationship: relation,
-    content: message,
-    font,
-  };
-
-  const handleSubmit = (event) => {
-    event.preventDefault();
-    postMessage(sendingData);
-    navigate(`/post/${id}`);
-  };
-
-  useEffect(() => {
-    const handleFormValid = () => {
-      if (senderName !== '' && messageValid !== false) {
-        setIsFormVaild(true);
-      } else {
-        setIsFormVaild(false);
-      }
-    };
-    handleFormValid();
-  }, [senderName, messageValid]);
+  const {
+    setSenderName,
+    setProfileImage,
+    setRelation,
+    setMessage,
+    setMessageValid,
+    setFont,
+    isFormValid,
+    handleSubmit,
+  } = useSendMessage();
 
   return (
     <div>


### PR DESCRIPTION
### :memo: 이슈 내용
커스텀훅으로 기능 분리

### :page_facing_up: 상세 내용
- ProfileSelect, NameInput, DropDown, TextEditor, SendMessagePage의 기능과 UI를 커스텀훅을 통해 분리했습니다.

### :white_check_mark: 체크리스트
- [x] ProfileSelect
- [x] NameInput
- [x] DropDown
- [x] TextEditor
- [x] SendMessagePage
