### PR TITLE
메인페이지 버튼에 페이지 이동 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ function App() {
         <Route path="post/:id" element={<CreatedRollingPage />} />
         <Route path="post/:id/edit" element={<CreatedRolloingPageEdit />} />
         <Route path="post/:id/message" element={<SendMessagePage />} />
-        <Route path="post" elemet={<PostPage />} />
+        <Route path="post" element={<PostPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/GlobalNav.jsx
+++ b/src/components/GlobalNav.jsx
@@ -1,18 +1,31 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import logoImage from '../assets/logo.svg';
 import OutlinedButton from './OutlinedButton';
 import device from '../config';
 
 function GlobalNav({ hasButton = false }) {
+  const navigate = useNavigate();
+
+  const handleClickLogo = () => {
+    navigate('/');
+  };
+
+  const handleClickMake = () => {
+    navigate('/post');
+  };
+
   return (
     <Nav $hasButton={hasButton}>
-      <Logo>
+      <Logo onClick={handleClickLogo}>
         <img className="logoImage" src={logoImage} alt="로고이미지" />
         <div className="logoTitle">Rolling</div>
       </Logo>
       {hasButton ? (
-        <OutlinedButton size={40}>롤링 페이퍼 만들기</OutlinedButton>
+        <OutlinedButton onClick={handleClickMake} size={40}>
+          롤링 페이퍼 만들기
+        </OutlinedButton>
       ) : null}
     </Nav>
   );

--- a/src/constants/dropdownEnum.jsx
+++ b/src/constants/dropdownEnum.jsx
@@ -8,6 +8,6 @@ export const RELATIONS = [
 export const FONTS = [
   { value: '1', label: 'Noto Sans' },
   { value: '2', label: 'Pretendard' },
-  { value: '3', label: '나눔 명조' },
+  { value: '3', label: '나눔명조' },
   { value: '4', label: '나눔손글씨 손편지체' },
 ];

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import GlobalNav from '../components/GlobalNav';
 import SiteInfo from '../components/SiteInfo';
@@ -25,6 +26,12 @@ const SITE_INFOS = [
 ];
 
 function MainPage() {
+  const navigate = useNavigate();
+
+  const handleClickReadMore = () => {
+    navigate('/post/list');
+  };
+
   return (
     <div>
       <GlobalNav hasButton />
@@ -44,7 +51,12 @@ function MainPage() {
             message={SITE_INFOS[1].message}
             imgUrl={SITE_INFOS[1].imgUrl}
           />
-          <Button className="readMore" size={280} shape={56}>
+          <Button
+            className="readMore"
+            size={280}
+            shape={56}
+            onClick={handleClickReadMore}
+          >
             구경해보기
           </Button>
         </SiteInfoWrapper>


### PR DESCRIPTION
- 메인페이지의 구경해보기 버튼 클릭 시 /list 페이지로 이동
- GlobalNav의 로고 클릭 시 / 페이지로 이동
- GlobalNav의 롤링페이퍼 만들기 버튼 클릭 시 /post 페이지로 이동